### PR TITLE
fix: 修复7.0绘灵法师装备显示异常

### DIFF
--- a/data/out/jobCategories.js
+++ b/data/out/jobCategories.js
@@ -280,6 +280,7 @@ export default [
     BLM: true,
     SMN: true,
     RDM: true,
+    PCT: true,
   },
   ,
   ,


### PR DESCRIPTION
<img width="414" alt="image" src="https://github.com/Asvel/ffxiv-gearing/assets/8666955/11ae879f-a498-4d80-8e6f-7ad50f37070e">
绘灵法师装备显示不全